### PR TITLE
feat: remove analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The following settings can be configured:
 | Setting                    | Description                                                                                                                                                                           | Default  |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | Mark notifications as read | Allow notifications to be marked as read when you add those videos to your Watch Later playlist.                                                                                      | disabled |
-| Analytics                  | Allow successful button clicks to be sent to my personal analytics site. It is just a fun little way for me to see if other people find it useful. Feel free to disable this, though! | disabled |
 | Logging                    | Allow the extension to send logs to your console. Could be useful for debugging purposes.                                                                                             | disabled |
 
 ## Changelog

--- a/src/background/messages/settings.ts
+++ b/src/background/messages/settings.ts
@@ -19,20 +19,10 @@ const markNotificationsAsRead = async (): Promise<boolean> => {
   return markNotificationsAsRead
 }
 
-const analyticsEnabled = async (): Promise<boolean> => {
-  const storage = new Storage()
-  const analyticsEnabled: boolean = await storage.get(
-    'analyticsEnabled',
-  )
-  
-  return analyticsEnabled
-}
-
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const settings: Settings = {
     loggingEnabled: await loggingEnabled(),
     markNotificationsAsRead: await markNotificationsAsRead(),
-    analyticsEnabled: await analyticsEnabled(),
   }
 
   res.send(settings)

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -10,7 +10,7 @@ import { sendToBackgroundViaRelay } from '@plasmohq/messaging'
 
 import { hasPath, hasSearch } from '~helpers/browser'
 import { logError, logLine } from '~helpers/logging'
-import { markNotificationsAsRead, analyticsEnabled } from '~helpers/system'
+import { markNotificationsAsRead } from '~helpers/system'
 import type { YTData } from '~interfaces'
 import { useWatchLaterStore } from '~store'
 
@@ -275,34 +275,6 @@ const WatchLaterButton = ({ anchor }) => {
     return classes.join(' ')
   }, [status, ytData?.clientTheme])
 
-  const trackClick = async () => {
-    if (!(await analyticsEnabled())) {
-      logLine('Analytics is disabled')
-      return
-    }
-
-    const response = await fetch('https://analytics.dnwjn.io/api/event', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        domain: 'youtube-watch-later-extension',
-        name: 'buttonclick',
-        url: window.location.href,
-        props: {
-          variation: isInNotification ? 'notification' : 'thumbnail',
-        }
-      }),
-    })
-
-    if (response.ok) {
-      logLine('Click tracked')
-    } else {
-      logError('Failed to track click')
-    }
-  }
-
   const addVideo = async (event) => {
     event.stopPropagation()
 
@@ -322,8 +294,6 @@ const WatchLaterButton = ({ anchor }) => {
             if (isInNotification) {
               markNotificationAsRead()
             }
-
-            trackClick()
           })
           .catch(() => setStatus(4))
           .finally(() => {

--- a/src/helpers/system.ts
+++ b/src/helpers/system.ts
@@ -17,13 +17,3 @@ export const markNotificationsAsRead = async (): Promise<boolean> => {
   
   return settings.markNotificationsAsRead
 }
-
-export const analyticsEnabled = async (): Promise<boolean> => {
-  if (process.env.NODE_ENV !== 'production') return false
-
-  const settings: Settings = await sendToBackgroundViaRelay<Settings>({
-    name: 'settings',
-  })
-  
-  return settings.analyticsEnabled
-}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,5 +9,4 @@ export interface YTData {
 export interface Settings {
   loggingEnabled: boolean
   markNotificationsAsRead: boolean
-  analyticsEnabled: boolean
 }

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -13,7 +13,6 @@ const Popup = () => {
   const [isLogging, setIsLogging] = useStorage<boolean>('isLogging', false)
   const [markNotificationsAsRead, setMarkNotificationsAsRead] =
     useStorage<boolean>('markNotificationsAsRead', false)
-  const [analyticsEnabled, setAnalyticsEnabled] = useStorage<boolean>('analyticsEnabled', false)
 
   const version = useMemo(() => {
     if (process.env.NODE_ENV === 'production') {
@@ -79,32 +78,6 @@ const Popup = () => {
 
           <p className="instruction spacing">
             When enabled, notifications will be marked as read when you add them to Watch Later.
-          </p>
-        </div>
-
-        <div className="setting">
-          <h3 className="title">Analytics</h3>
-
-          <button
-            className="button"
-            onClick={() =>
-              setAnalyticsEnabled(!analyticsEnabled)
-            }>
-            <div className="default">
-              <span className="status">
-                {analyticsEnabled ? 'Enabled' : 'Disabled'}
-              </span>
-            </div>
-            <div className="hover">
-              <span className="status">
-                {analyticsEnabled ? 'Disable' : 'Enable'}
-              </span>
-            </div>
-          </button>
-
-          <p className="instruction spacing">
-            When enabled, button clicks will be tracked. This is purely for my own curiosity :).
-            Feel free to disable it though!
           </p>
         </div>
 


### PR DESCRIPTION
Even though it was for personal use only, it shouldn’t be there now. Let’s keep it simple.