### PR TITLE
Feat: Add button to suggested videos on player page

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:source": "./bin/build-source.sh",
     "build:bundle": "plasmo build --source-maps --bundle-buddy",
     "package": "plasmo package",
-    "pretty": "prettier --write src/**/*.{ts,tsx}",
+    "pretty": "prettier --write src/*.{ts,tsx} src/**/*.{ts,tsx}",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "bump-patch": "npm version patch --no-git-tag-version",
     "bump-minor": "npm version minor --no-git-tag-version",

--- a/src/contents/button.styles.ts
+++ b/src/contents/button.styles.ts
@@ -21,7 +21,7 @@ export const buttonStyles = `
     z-index: 10;
     cursor: pointer;
     font-size: 12px;
-    border-radius: 8px;
+    border-radius: 18px;
     outline: none;
 }
 
@@ -108,7 +108,6 @@ export const buttonStyles = `
     position: relative;
     margin-left: 8px;
     margin-right: 8px;
-    border-radius: 18px;
     color: #f1f1f1;
     width: 36px;
     height: 36px;

--- a/src/contents/button.styles.ts
+++ b/src/contents/button.styles.ts
@@ -104,6 +104,13 @@ export const buttonStyles = `
     bottom: 8px;
 }
 
+.watch-later-btn.in-player-suggested {
+    left: unset;
+    top: unset;
+    right: -10px;
+    bottom: 8px;
+}
+
 .watch-later-btn.in-video-detail {
     position: relative;
     margin-left: 8px;
@@ -117,15 +124,18 @@ export const buttonStyles = `
     color: #0f0f0f;
 }
 
-.watch-later-btn.light.in-notification {
+.watch-later-btn.light.in-notification,
+.watch-later-btn.light.in-player-suggested {
     color: #030303;
 }
 
-.watch-later-btn.dark.in-notification:not(.loading):not(.success):not(.error):hover {
+.watch-later-btn.dark.in-notification:not(.loading):not(.success):not(.error):hover,
+.watch-later-btn.dark.in-player-suggested:not(.loading):not(.success):not(.error):hover {
     background-color: rgba(255,255,255,0.2);
 }
 
-.watch-later-btn.light.in-notification:not(.loading):not(.success):not(.error):hover {
+.watch-later-btn.light.in-notification:not(.loading):not(.success):not(.error):hover,
+.watch-later-btn.light.in-player-suggested:not(.loading):not(.success):not(.error):hover {
     background-color: rgba(0,0,0,0.1);
 }
 

--- a/src/contents/button.styles.ts
+++ b/src/contents/button.styles.ts
@@ -76,7 +76,7 @@ export const buttonStyles = `
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
-.watch-later-btn.dark.in-video-detail {
+.watch-later-btn.dark.on-video-detail {
     background-color: var(--yt-spec-menu-background);
 }
 
@@ -84,7 +84,7 @@ export const buttonStyles = `
 .watch-later-btn.light.in-playlist,
 .watch-later-btn.light.in-endscreen-suggested,
 .watch-later-btn.light.in-mod-endscreen-suggested,
-.watch-later-btn.light.in-video-detail {
+.watch-later-btn.light.on-video-detail {
     background-color: rgba(0,0,0,0.05);
 }
 
@@ -111,7 +111,7 @@ export const buttonStyles = `
     bottom: 8px;
 }
 
-.watch-later-btn.in-video-detail {
+.watch-later-btn.on-video-detail {
     position: relative;
     margin-left: 8px;
     margin-right: 8px;
@@ -120,8 +120,18 @@ export const buttonStyles = `
     height: 36px;
 }
 
-.watch-later-btn.light.in-video-detail {
+.watch-later-btn.light.on-video-detail {
     color: #0f0f0f;
+}
+
+.watch-later-btn.in-player-suggested-mobile {
+    z-index: 0;
+    position: relative;
+    margin-left: 6px;
+    margin-right: 6px;
+    color: #f1f1f1;
+    width: 36px;
+    height: 36px;
 }
 
 .watch-later-btn.light.in-notification,
@@ -139,11 +149,11 @@ export const buttonStyles = `
     background-color: rgba(0,0,0,0.1);
 }
 
-.watch-later-btn.dark.in-video-detail:not(.loading):not(.success):not(.error):hover {
+.watch-later-btn.dark.on-video-detail:not(.loading):not(.success):not(.error):hover {
     background-color: var(--yt-spec-outline);
 }
 
-.watch-later-btn.light.in-video-detail:not(.loading):not(.success):not(.error):hover {
+.watch-later-btn.light.on-video-detail:not(.loading):not(.success):not(.error):hover {
     background-color: rgba(0,0,0,0.1);
 }
 

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -1,26 +1,11 @@
-import type {
-  PlasmoCSConfig,
-  PlasmoGetInlineAnchorList,
-  PlasmoGetStyle,
-  PlasmoMountShadowHost,
-} from 'plasmo'
+import type { PlasmoCSConfig, PlasmoGetInlineAnchorList, PlasmoGetStyle, PlasmoMountShadowHost } from 'plasmo'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import { getAuthorizationHeader } from '~helpers/api'
-import {
-  extractVideoId,
-  hasPath,
-  hasSearch,
-  isVideoUrl,
-} from '~helpers/browser'
+import { extractVideoId, hasPath, hasSearch, isVideoUrl } from '~helpers/browser'
 import { elementIsAnchor } from '~helpers/dom'
 import { logError, logLine } from '~helpers/logging'
-import {
-  buttonOpacity,
-  buttonPosition,
-  buttonVisibility,
-  markNotificationsAsRead,
-} from '~helpers/system'
+import { buttonOpacity, buttonPosition, buttonVisibility, markNotificationsAsRead } from '~helpers/system'
 import useVideoPreviewListener from '~hooks/useVideoPreviewListener'
 import type { ButtonConfig, YTData } from '~interfaces'
 import { useWatchLaterStore } from '~store'
@@ -42,16 +27,28 @@ export const getStyle: PlasmoGetStyle = () => {
   return style
 }
 
+const anchorListSelectors = [
+  // General videos
+  'ytd-rich-item-renderer',
+  // Videos on playlist page
+  'ytd-playlist-video-renderer',
+  // Videos in notification drawer
+  'ytd-notification-renderer',
+  // Videos on search page
+  'ytd-search ytd-video-renderer',
+  // Suggested videos in video player when finished
+  '.ytp-endscreen-content .ytp-videowall-still',
+  '.ytp-fullscreen-grid .ytp-modern-videowall-still',
+  // Buttons below video player
+  'ytd-watch-metadata #top-level-buttons-computed',
+  // Suggested videos next to video player
+  'yt-lockup-view-model.ytd-item-section-renderer > .yt-lockup-view-model',
+  // Suggested videos below video player on mobile
+  'ytm-media-item .media-item-menu',
+]
+
 export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
-  const elements = document.querySelectorAll(
-    'ytd-rich-item-renderer, \
-    ytd-playlist-video-renderer, \
-    ytd-notification-renderer, \
-    ytd-search ytd-video-renderer, \
-    .ytp-endscreen-content .ytp-videowall-still, \
-    .ytp-fullscreen-grid .ytp-modern-videowall-still, \
-    ytd-watch-metadata #top-level-buttons-computed',
-  )
+  const elements = document.querySelectorAll(anchorListSelectors.join(','))
 
   return (
     Array.from(elements)
@@ -185,11 +182,12 @@ const WatchLaterButton = ({ anchor }) => {
   })
   const [isHovered, setIsHovered] = useState(false)
 
-  const isInThumbnail = [
-    'YTD-RICH-ITEM-RENDERER',
-    'YTD-GRID-VIDEO-RENDERER',
-    'YTD-VIDEO-RENDERER',
-  ].includes(element.tagName)
+  const isInThumbnail =
+    [
+      'YTD-RICH-ITEM-RENDERER',
+      'YTD-GRID-VIDEO-RENDERER',
+      'YTD-VIDEO-RENDERER',
+    ].includes(element.tagName)
   const isInPlaylist = ['YTD-PLAYLIST-VIDEO-RENDERER'].includes(element.tagName)
   const isInNotification = ['YTD-NOTIFICATION-RENDERER'].includes(
     element.tagName,
@@ -201,6 +199,7 @@ const WatchLaterButton = ({ anchor }) => {
     'ytp-modern-videowall-still',
   )
   const isInVideoDetail = element.id === 'top-level-buttons-computed'
+  const isInPlayerSuggested = element.classList.contains('yt-lockup-view-model')
 
   const buttonClasses = useMemo(() => {
     let classes = ['watch-later-btn']
@@ -233,6 +232,9 @@ const WatchLaterButton = ({ anchor }) => {
     }
     if (isInVideoDetail) {
       classes.push('in-video-detail')
+    }
+    if (isInPlayerSuggested) {
+      classes.push('in-player-suggested')
     }
 
     if (ytData?.clientTheme === 'USER_INTERFACE_THEME_DARK') {

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -1,11 +1,32 @@
-import type { PlasmoCSConfig, PlasmoGetInlineAnchorList, PlasmoGetStyle, PlasmoMountShadowHost } from 'plasmo'
+import type {
+  PlasmoCSConfig,
+  PlasmoGetInlineAnchorList,
+  PlasmoGetStyle,
+  PlasmoMountShadowHost,
+} from 'plasmo'
 import React, { useEffect, useMemo, useState } from 'react'
 
-import { getAuthorizationHeader } from '~helpers/api'
-import { extractVideoId, hasPath, hasSearch, isVideoUrl } from '~helpers/browser'
-import { elementIsAnchor } from '~helpers/dom'
+import { getAuthorizationHeader, getHostname } from '~helpers/api'
+import { hasPath, hasSearch } from '~helpers/browser'
+import { getVideoId } from '~helpers/extracting'
 import { logError, logLine } from '~helpers/logging'
-import { buttonOpacity, buttonPosition, buttonVisibility, markNotificationsAsRead } from '~helpers/system'
+import {
+  elementIsInEndscreenSuggested,
+  elementIsInMobilePlayerSuggested,
+  elementIsInModernEndscreenSuggested,
+  elementIsInNotification,
+  elementIsInPlayerSuggested,
+  elementIsInPlaylist,
+  elementIsInThumbnail,
+  elementIsOnVideoDetailPage,
+  elementNeedsButton,
+} from '~helpers/matching'
+import {
+  buttonOpacity,
+  buttonPosition,
+  buttonVisibility,
+  markNotificationsAsRead,
+} from '~helpers/system'
 import useVideoPreviewListener from '~hooks/useVideoPreviewListener'
 import type { ButtonConfig, YTData } from '~interfaces'
 import { useWatchLaterStore } from '~store'
@@ -55,20 +76,7 @@ export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
       // Filter out elements that already have the button.
       .filter((element) => !element.querySelector('.watch-later-btn'))
       // Filter out elements that are not a video.
-      .filter((element) => {
-        if (elementIsAnchor(element)) {
-          return isVideoUrl((element as HTMLAnchorElement).href)
-        }
-
-        // For video detail page, check if we're on a watch page or shorts page.
-        if (element.id === 'top-level-buttons-computed') {
-          return window.location.pathname.match(/^\/(watch|shorts)/)
-        }
-
-        return Array.from(element.querySelectorAll('a')).some((a) =>
-          isVideoUrl(a.href),
-        )
-      })
+      .filter((element) => elementNeedsButton(element))
       .map((element) => ({
         element,
         insertPosition: 'beforebegin',
@@ -81,8 +89,14 @@ export const mountShadowHost: PlasmoMountShadowHost = ({
   anchor,
   mountState,
 }) => {
-  // Insert the shadow host as the first child of the anchor element.
-  anchor.element.insertBefore(shadowHost, anchor.element.firstChild)
+  const element = anchor.element
+
+  if (elementIsInMobilePlayerSuggested(element)) {
+    element.appendChild(shadowHost)
+  } else {
+    element.insertBefore(shadowHost, element.firstChild)
+  }
+
   mountState.observer.disconnect()
 }
 
@@ -182,24 +196,15 @@ const WatchLaterButton = ({ anchor }) => {
   })
   const [isHovered, setIsHovered] = useState(false)
 
-  const isInThumbnail =
-    [
-      'YTD-RICH-ITEM-RENDERER',
-      'YTD-GRID-VIDEO-RENDERER',
-      'YTD-VIDEO-RENDERER',
-    ].includes(element.tagName)
-  const isInPlaylist = ['YTD-PLAYLIST-VIDEO-RENDERER'].includes(element.tagName)
-  const isInNotification = ['YTD-NOTIFICATION-RENDERER'].includes(
-    element.tagName,
-  )
-  const isInEndscreenSuggested = element.classList.contains(
-    'ytp-videowall-still',
-  )
-  const isInModernEndscreenSuggested = element.classList.contains(
-    'ytp-modern-videowall-still',
-  )
-  const isInVideoDetail = element.id === 'top-level-buttons-computed'
-  const isInPlayerSuggested = element.classList.contains('yt-lockup-view-model')
+  const isInThumbnail = elementIsInThumbnail(element)
+  const isInPlaylist = elementIsInPlaylist(element)
+  const isInNotification = elementIsInNotification(element)
+  const isInEndscreenSuggested = elementIsInEndscreenSuggested(element)
+  const isInModernEndscreenSuggested =
+    elementIsInModernEndscreenSuggested(element)
+  const isOnVideoDetail = elementIsOnVideoDetailPage(element)
+  const isInPlayerSuggested = elementIsInPlayerSuggested(element)
+  const isInPlayerSuggestedMobile = elementIsInMobilePlayerSuggested(element)
 
   const buttonClasses = useMemo(() => {
     let classes = ['watch-later-btn']
@@ -230,11 +235,14 @@ const WatchLaterButton = ({ anchor }) => {
     if (isInModernEndscreenSuggested) {
       classes.push('in-mod-endscreen-suggested')
     }
-    if (isInVideoDetail) {
-      classes.push('in-video-detail')
+    if (isOnVideoDetail) {
+      classes.push('on-video-detail')
     }
     if (isInPlayerSuggested) {
       classes.push('in-player-suggested')
+    }
+    if (isInPlayerSuggestedMobile) {
+      classes.push('in-player-suggested-mobile')
     }
 
     if (ytData?.clientTheme === 'USER_INTERFACE_THEME_DARK') {
@@ -259,7 +267,7 @@ const WatchLaterButton = ({ anchor }) => {
 
   const shouldShow = useMemo(() => {
     if (status === 0) return false
-    if (isInVideoDetail) return true // Always show on video detail page
+    if (isOnVideoDetail) return true // Always show on video detail page
     if (buttonConfig.visibility === ButtonVisibility.Always) return true
     if (isHovered) return true
     if (videoPreviewIsHovered && latestElementRef === element) return true
@@ -270,7 +278,7 @@ const WatchLaterButton = ({ anchor }) => {
     isHovered,
     videoPreviewIsHovered,
     latestElementRef,
-    isInVideoDetail,
+    isOnVideoDetail,
   ])
 
   const fetchButtonConfig = async () => {
@@ -291,20 +299,7 @@ const WatchLaterButton = ({ anchor }) => {
 
     if (status !== 1) return
 
-    let videoId: string | null = null
-
-    if (isInVideoDetail) {
-      // For video detail page, get video ID from current URL
-      videoId = extractVideoId(window.location.href)
-    } else {
-      // For other pages, get video ID from element
-      const videoUrl = elementIsAnchor(element)
-        ? element.href
-        : element.querySelector('a')?.href
-      if (videoUrl) {
-        videoId = extractVideoId(videoUrl)
-      }
-    }
+    const videoId: string | null = getVideoId(element)
 
     if (videoId && ytData) {
       setStatus(2)
@@ -338,7 +333,7 @@ const WatchLaterButton = ({ anchor }) => {
         }
 
         const response = await _apiPost(
-          'https://www.youtube.com/youtubei/v1/browse/edit_playlist?prettyPrint=false',
+          'browse/edit_playlist?prettyPrint=false',
           payload,
         )
         const responseJson = await response.json()
@@ -381,7 +376,7 @@ const WatchLaterButton = ({ anchor }) => {
       }
 
       const response = await _apiPost(
-        'https://www.youtube.com/youtubei/v1/notification/record_interactions?prettyPrint=false',
+        'notification/record_interactions?prettyPrint=false',
         payload,
       )
       const responseJson = await response.json()
@@ -397,7 +392,7 @@ const WatchLaterButton = ({ anchor }) => {
   }
 
   const _apiPost = async (
-    url: string,
+    path: string,
     payload: object,
   ): Promise<Response | null> => {
     return new Promise(async (resolve, reject) => {
@@ -409,6 +404,7 @@ const WatchLaterButton = ({ anchor }) => {
         return
       }
 
+      const url = `https://${getHostname()}/youtubei/v1/${path}`
       const finalPayload = {
         ...payload,
         context: {
@@ -518,13 +514,13 @@ const WatchLaterButton = ({ anchor }) => {
 
     if (
       !enabled ||
-      (!isInNotification && !isInVideoDetail && (isWL || isPlaylists))
+      (!isInNotification && !isOnVideoDetail && (isWL || isPlaylists))
     ) {
       setVisible(false)
     } else {
       setVisible(true)
     }
-  }, [enabled, isInNotification, isInVideoDetail, url])
+  }, [enabled, isInNotification, isOnVideoDetail, url])
 
   useEffect(() => {
     if (visible && hasData) {

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -28,7 +28,11 @@ export const getAuthorizationHeader = async () => {
   const origin = 'https://www.youtube.com'
   const time = Math.floor(Date.now() / 1000)
   const hash = await sha1(`${time} ${sapisid} ${origin}`)
-  const authorizationHeader = `${time}_${hash}`
 
-  return authorizationHeader
+  return `${time}_${hash}`
+}
+
+export const getHostname = () => {
+  const hostname = window.location.hostname
+  return hostname.includes('youtube.com') ? hostname : 'www.youtube.com'
 }

--- a/src/helpers/browser.ts
+++ b/src/helpers/browser.ts
@@ -52,7 +52,7 @@ export const isVideoUrl = (url: string): boolean => {
   }
 }
 
-export const extractVideoId = (url: string): string | null => {
+export const extractVideoId = (url: string | null): string | null => {
   if (!url) return null
 
   try {

--- a/src/helpers/dom.ts
+++ b/src/helpers/dom.ts
@@ -1,1 +1,0 @@
-export const elementIsAnchor = (element: Element) => element.tagName === 'A'

--- a/src/helpers/extracting.ts
+++ b/src/helpers/extracting.ts
@@ -1,0 +1,22 @@
+import { extractVideoId, isVideoUrl } from '~helpers/browser'
+import {
+  elementIsAnchor,
+  elementIsInMobilePlayerSuggested,
+  elementIsOnVideoDetailPage,
+} from '~helpers/matching'
+
+export const getVideoId = (element: Element) => {
+  if (elementIsOnVideoDetailPage(element)) {
+    return extractVideoId(window.location.href)
+  }
+  if (elementIsInMobilePlayerSuggested(element)) {
+    return extractVideoId(getMobileSuggestedMenuHref(element))
+  }
+  if (elementIsAnchor(element)) {
+    return extractVideoId((element as HTMLAnchorElement).href)
+  }
+  return extractVideoId(element.querySelector('a')?.href)
+}
+
+export const getMobileSuggestedMenuHref = (element: Element) =>
+  element.closest('ytm-media-item')?.querySelector('a')?.href || ''

--- a/src/helpers/matching.ts
+++ b/src/helpers/matching.ts
@@ -1,0 +1,52 @@
+import { isVideoUrl } from '~helpers/browser'
+import { getMobileSuggestedMenuHref } from '~helpers/extracting'
+
+export const elementIsAnchor = (element: Element) => element.tagName === 'A'
+
+export const elementIsInThumbnail = (element: Element) =>
+  [
+    'YTD-RICH-ITEM-RENDERER',
+    'YTD-GRID-VIDEO-RENDERER',
+    'YTD-VIDEO-RENDERER',
+  ].includes(element.tagName)
+
+export const elementIsInPlaylist = (element: Element) =>
+  ['YTD-PLAYLIST-VIDEO-RENDERER'].includes(element.tagName)
+
+export const elementIsInNotification = (element: Element) =>
+  ['YTD-NOTIFICATION-RENDERER'].includes(element.tagName)
+
+export const elementIsInEndscreenSuggested = (element: Element) =>
+  element.classList.contains('ytp-videowall-still')
+
+export const elementIsInModernEndscreenSuggested = (element: Element) =>
+  element.classList.contains('ytp-modern-videowall-still')
+
+export const elementIsInPlayerSuggested = (element: Element) =>
+  element.classList.contains('yt-lockup-view-model')
+
+export const elementIsInMobilePlayerSuggested = (element: Element) =>
+  element.classList.contains('media-item-menu')
+
+export const elementIsOnVideoDetailPage = (element: Element) =>
+  element.id === 'top-level-buttons-computed'
+
+export const elementNeedsButton = (element: Element) => {
+  if (elementIsAnchor(element)) {
+    return isVideoUrl((element as HTMLAnchorElement).href)
+  }
+
+  // For video detail page, check if we're on a watch page or shorts page.
+  if (elementIsOnVideoDetailPage(element)) {
+    return window.location.pathname.match(/^\/(watch|shorts)/)
+  }
+
+  // For suggested videos on mobile player page, we need to find the anchor higher up in the hierarchy.
+  if (elementIsInMobilePlayerSuggested(element)) {
+    return isVideoUrl(getMobileSuggestedMenuHref(element))
+  }
+
+  return Array.from(element.querySelectorAll('a')).some((a) =>
+    isVideoUrl(a.href),
+  )
+}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -71,7 +71,7 @@ const Popup = () => {
           </p>
 
           <p className="instruction spacing">
-            Only affects the button inside the notification drawer.
+            This setting only affects the button inside the notification drawer.
           </p>
         </div>
 
@@ -102,6 +102,11 @@ const Popup = () => {
           A page reload is required for these settings to take effect.
         </p>
 
+        <p className="instruction spacing">
+          These settings do not affect the button inside the video player
+          controls and in the suggested videos.
+        </p>
+
         <div className="setting">
           <h3 className="title">Button visibility</h3>
 
@@ -128,10 +133,6 @@ const Popup = () => {
               <span className="status">Change to hover</span>
             </div>
           </button>
-
-          <p className="instruction spacing">
-            Does not affect the button inside the video player controls.
-          </p>
         </div>
 
         <div className="setting">
@@ -160,10 +161,6 @@ const Popup = () => {
               <span className="status">Change to half</span>
             </div>
           </button>
-
-          <p className="instruction spacing">
-            Does not affect the button inside the video player controls.
-          </p>
         </div>
 
         <div className="setting">
@@ -192,10 +189,6 @@ const Popup = () => {
               <span className="status">Move to top right</span>
             </div>
           </button>
-
-          <p className="instruction spacing">
-            Does not affect the button inside the video player controls.
-          </p>
         </div>
       </div>
 
@@ -203,14 +196,13 @@ const Popup = () => {
         <h2 className="title">Contact</h2>
 
         <p className="instruction">
-          Do you have a suggestion, an issue, or do you just want to say thank you?
+          Do you have a suggestion, an issue, or do you just want to say thank
+          you?
         </p>
 
         <button
           className="button bold"
-          onClick={() =>
-            openTab('https://youtube-watch-later.com')
-          }>
+          onClick={() => openTab('https://youtube-watch-later.com')}>
           Visit website
         </button>
       </div>
@@ -230,8 +222,7 @@ const Popup = () => {
             className="bmac-link"
             href="https://coff.ee/dnwjn"
             rel="noopener noreferrer"
-            target="_blank"
-          >
+            target="_blank">
             <img
               src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png"
               alt="Buy Me a Coffee"


### PR DESCRIPTION
# Features

- Added the "Add to Watch Later" button to the suggested videos on the side of the video player on desktop
- Added the "Add to Watch Later" button to the suggested videos below the video player on mobile

# Changes

- Changed the button shape to be round in all scenarios
- Extracted code to helpers to make main component smaller
- Added more comments to make code more readable

# Screenshots

Example of the suggested videos on desktop:
<img width="540" height="593" alt="SCR-20260330-phbz" src="https://github.com/user-attachments/assets/bf9d3a8a-ca65-4b96-a64c-02298462bb0f" />

Example of the suggested videos on mobile:
<img width="538" height="1041" alt="SCR-20260330-phwc" src="https://github.com/user-attachments/assets/af0308f1-aec5-4e8b-b5e9-cc870e09b8da" />

Implements #192.