### PR TITLE
Fix: Multi account containers

### DIFF
--- a/src/background/messages/visitor-cookie.ts
+++ b/src/background/messages/visitor-cookie.ts
@@ -1,9 +1,15 @@
 import type { PlasmoMessaging } from '@plasmohq/messaging'
 
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const cookieStoreId = (req.sender?.tab as any)?.cookieStoreId as string | undefined
+
   const sapisidCookie = await new Promise<string | null>((resolve, reject) => {
     chrome.cookies.get(
-      { url: 'https://www.youtube.com', name: 'SAPISID' },
+      {
+        url: 'https://www.youtube.com',
+        name: 'SAPISID',
+        ...(cookieStoreId ? { storeId: cookieStoreId } : {}),
+      },
       (cookie) => {
         if (cookie) {
           resolve(cookie.value)

--- a/src/background/messages/visitor-cookie.ts
+++ b/src/background/messages/visitor-cookie.ts
@@ -3,24 +3,30 @@ import type { PlasmoMessaging } from '@plasmohq/messaging'
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const cookieStoreId = (req.sender?.tab as any)?.cookieStoreId as string | undefined
 
-  const sapisidCookie = await new Promise<string | null>((resolve, reject) => {
-    chrome.cookies.get(
-      {
-        url: 'https://www.youtube.com',
-        name: 'SAPISID',
-        ...(cookieStoreId ? { storeId: cookieStoreId } : {}),
-      },
-      (cookie) => {
-        if (cookie) {
-          resolve(cookie.value)
-        } else {
-          reject('SAPISID cookie not found')
-        }
-      },
-    )
-  })
+  const getCookie = (name: string): Promise<string | null> => {
+    return new Promise((resolve) => {
+      chrome.cookies.get(
+        {
+          url: 'https://www.youtube.com',
+          name,
+          ...(cookieStoreId ? { storeId: cookieStoreId } : {}),
+        },
+        (cookie) => resolve(cookie?.value ?? null),
+      )
+    })
+  }
 
-  res.send(sapisidCookie)
+  const [sapisid, sapisid1p, sapisid3p] = await Promise.all([
+    getCookie('SAPISID'),
+    getCookie('__Secure-1PAPISID'),
+    getCookie('__Secure-3PAPISID'),
+  ])
+
+  if (!sapisid) {
+    throw new Error('SAPISID cookie not found')
+  }
+
+  res.send({ sapisid, sapisid1p, sapisid3p })
 }
 
 export default handler

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -418,7 +418,7 @@ const WatchLaterButton = ({ anchor }) => {
       const response = await fetch(url, {
         method: 'POST',
         headers: {
-          Authorization: `SAPISIDHASH ${authorizationHeader}`,
+          Authorization: authorizationHeader,
           'Content-Type': 'application/json',
           'X-Origin': 'https://www.youtube.com',
           'X-Goog-Authuser': authUser,

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,10 +1,6 @@
 import { sendToBackgroundViaRelay } from '@plasmohq/messaging'
 
-interface VisitorCookies {
-  sapisid: string
-  sapisid1p: string | null
-  sapisid3p: string | null
-}
+import type { VisitorCookies } from '~interfaces'
 
 const sha1 = async (message: string) => {
   const encoder = new TextEncoder()

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,5 +1,11 @@
 import { sendToBackgroundViaRelay } from '@plasmohq/messaging'
 
+interface VisitorCookies {
+  sapisid: string
+  sapisid1p: string | null
+  sapisid3p: string | null
+}
+
 const sha1 = async (message: string) => {
   const encoder = new TextEncoder()
   const data = encoder.encode(message)
@@ -10,26 +16,36 @@ const sha1 = async (message: string) => {
 }
 
 export const getAuthorizationHeader = async () => {
-  let sapisidCookie: string | null
+  let cookies: VisitorCookies
 
   try {
-    sapisidCookie = await sendToBackgroundViaRelay<string | null>({
+    cookies = await sendToBackgroundViaRelay<VisitorCookies>({
       name: 'visitor-cookie',
     })
   } catch (error) {
     throw new Error('Visitor cookie not found. Reason: ' + error)
   }
 
-  if (!sapisidCookie) {
+  if (!cookies?.sapisid) {
     throw new Error('Visitor cookie not found. Reason: no value')
   }
 
-  const sapisid = sapisidCookie
   const origin = 'https://www.youtube.com'
   const time = Math.floor(Date.now() / 1000)
-  const hash = await sha1(`${time} ${sapisid} ${origin}`)
 
-  return `${time}_${hash}`
+  const computeHash = async (cookieValue: string) =>
+    `${time}_${await sha1(`${time} ${cookieValue} ${origin}`)}`
+
+  const parts = [`SAPISIDHASH ${await computeHash(cookies.sapisid)}`]
+
+  if (cookies.sapisid1p) {
+    parts.push(`SAPISID1PHASH ${await computeHash(cookies.sapisid1p)}`)
+  }
+  if (cookies.sapisid3p) {
+    parts.push(`SAPISID3PHASH ${await computeHash(cookies.sapisid3p)}`)
+  }
+
+  return parts.join(' ')
 }
 
 export const getHostname = () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,3 +20,9 @@ export interface ButtonConfig {
   position: string
   visibility: string
 }
+
+export interface VisitorCookies {
+  sapisid: string
+  sapisid1p: string | null
+  sapisid3p: string | null
+}


### PR DESCRIPTION
This PR fixes an issue where the button would not work in Firefox, in combination with the `Multi-Account Containers` extension.

Context provided by the reporter:

> For a clean check, I installed a fresh Firefox in a Windows sandbox, then installed your extension and Multi-Account Containers. Then I logged into the same YouTube account, opened the same video, and tried to add the video by pressing the clock button. I got two different results.

# Bug fixes

- Respect cookie store ID (if present) when retrieving a cookie
- Besides `SAPISID`, also use `__Secure-1PAPISID` and `__Secure-3PAPISID` (if present) when making calls to the YouTube API

# Tests

I was able to replicate the reporter's issue, and after implementing the fixes, the button worked as expected.