### PR TITLE
Fix: Add support for new class used by YT

### DIFF
--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -64,6 +64,8 @@ const anchorListSelectors = [
   'ytd-watch-metadata #top-level-buttons-computed',
   // Suggested videos next to video player
   'yt-lockup-view-model.ytd-item-section-renderer > .yt-lockup-view-model',
+  // Suggested videos next to video player (new classname since May 2026)
+  'yt-lockup-view-model.ytd-item-section-renderer > .ytLockupViewModelHost',
   // Suggested videos below video player on mobile
   'ytm-media-item .media-item-menu',
 ]

--- a/src/helpers/matching.ts
+++ b/src/helpers/matching.ts
@@ -24,6 +24,7 @@ export const elementIsInModernEndscreenSuggested = (element: Element) =>
 
 export const elementIsInPlayerSuggested = (element: Element) =>
   element.classList.contains('yt-lockup-view-model')
+  || element.classList.contains('ytLockupViewModelHost')
 
 export const elementIsInMobilePlayerSuggested = (element: Element) =>
   element.classList.contains('media-item-menu')


### PR DESCRIPTION
This PR fixes an issue where the button would not show up in the suggested videos on the right side of the video player.

# Bug fixes

- Added support for new class `ytLockupViewModelHost`, which seems to be used instead of `yt-lockup-view-model` since recently

# Reports

- #202 
- https://chromewebstore.google.com/reviews/5837cf39-d4cf-44d2-976c-f1b24ed163da

# Tests

I was able to replicate the reported issue, and after implementing the fixes, the button worked as expected:

<img width="840" height="728" alt="50206" src="https://github.com/user-attachments/assets/463647d7-badd-4877-96cf-005d2744d343" />

---

Fixes #202.