### PR TITLE
Fix: Allow 1p and 3p cookie fallbacks

### DIFF
--- a/src/background/messages/visitor-cookie.ts
+++ b/src/background/messages/visitor-cookie.ts
@@ -22,7 +22,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
     getCookie('__Secure-3PAPISID'),
   ])
 
-  if (!sapisid) {
+  if (!sapisid && !sapisid1p && !sapisid3p) {
     throw new Error('SAPISID cookie not found')
   }
 

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -22,7 +22,7 @@ export const getAuthorizationHeader = async () => {
     throw new Error('Visitor cookie not found. Reason: ' + error)
   }
 
-  if (!cookies?.sapisid) {
+  if (!cookies?.sapisid && !cookies?.sapisid1p && !cookies?.sapisid3p) {
     throw new Error('Visitor cookie not found. Reason: no value')
   }
 
@@ -32,8 +32,11 @@ export const getAuthorizationHeader = async () => {
   const computeHash = async (cookieValue: string) =>
     `${time}_${await sha1(`${time} ${cookieValue} ${origin}`)}`
 
-  const parts = [`SAPISIDHASH ${await computeHash(cookies.sapisid)}`]
+  const parts: string[] = []
 
+  if (cookies.sapisid) {
+    parts.push(`SAPISIDHASH ${await computeHash(cookies.sapisid)}`)
+  }
   if (cookies.sapisid1p) {
     parts.push(`SAPISID1PHASH ${await computeHash(cookies.sapisid1p)}`)
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,7 +22,7 @@ export interface ButtonConfig {
 }
 
 export interface VisitorCookies {
-  sapisid: string
+  sapisid: string | null
   sapisid1p: string | null
   sapisid3p: string | null
 }


### PR DESCRIPTION
This PR fixes an issue where the YouTube cookie fallbacks were not allowed in case the primary cookie was not set. It seems that the alternative cookies are served without the primary cookie more and more, so this change allows any of the three.

---

Fixes #201.