### PR TITLE
Feat: Add more button positions

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,8 +1,49 @@
 import packageJson from '@root/package.json'
 
-import { changelog, type ChangelogVersion } from '~changelog'
+import { Storage } from '@plasmohq/storage'
 
-chrome.runtime.onInstalled.addListener(({ reason }) => {
+import { changelog, type ChangelogVersion } from '~changelog'
+import { ButtonPosition, buttonPositionAllowed } from '~types'
+
+const clampToAllowed = (position: string, allowed: string[]): string => {
+  if (allowed.includes(position)) return position
+
+  const isTop =
+    position === ButtonPosition.TopLeft || position === ButtonPosition.TopRight
+
+  const sameVerticalHalf = allowed.find((candidate) => {
+    const candidateIsTop =
+      candidate === ButtonPosition.TopLeft ||
+      candidate === ButtonPosition.TopRight
+
+    return candidateIsTop === isTop
+  })
+
+  return sameVerticalHalf ?? allowed[0]
+}
+
+const migrateButtonPosition = async () => {
+  const storage = new Storage()
+  const legacyPosition: string | undefined = await storage.get('buttonPosition')
+
+  if (!legacyPosition) return
+
+  await Promise.all(
+    Object.entries(buttonPositionAllowed).map(async ([context, allowed]) => {
+      const existing = await storage.get(context)
+
+      if (existing) return
+
+      await storage.set(context, clampToAllowed(legacyPosition, allowed))
+    }),
+  )
+}
+
+chrome.runtime.onInstalled.addListener(async ({ reason }) => {
+  if (reason === 'update') {
+    await migrateButtonPosition()
+  }
+
   if (
     reason === 'update' &&
     changelog.some((c: ChangelogVersion) => c.version === packageJson.version)

--- a/src/background/messages/settings.ts
+++ b/src/background/messages/settings.ts
@@ -2,6 +2,7 @@ import type { PlasmoMessaging } from '@plasmohq/messaging'
 import { Storage } from '@plasmohq/storage'
 
 import type { Settings } from '~interfaces'
+import { ButtonPositionContext, buttonPositionDefault } from '~types'
 
 const buttonOpacity = async (): Promise<string> => {
   const storage = new Storage()
@@ -10,11 +11,11 @@ const buttonOpacity = async (): Promise<string> => {
   return buttonOpacity
 }
 
-const buttonPosition = async (): Promise<string> => {
+const buttonPosition = async (context: string): Promise<string> => {
   const storage = new Storage()
-  const buttonPosition: string = await storage.get('buttonPosition')
+  const position: string = await storage.get(context)
 
-  return buttonPosition
+  return position || buttonPositionDefault[context]
 }
 
 const buttonVisibility = async (): Promise<string> => {
@@ -43,7 +44,24 @@ const markNotificationsAsRead = async (): Promise<boolean> => {
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
   const settings: Settings = {
     buttonOpacity: await buttonOpacity(),
-    buttonPosition: await buttonPosition(),
+    buttonPositionThumbnail: await buttonPosition(
+      ButtonPositionContext.Thumbnail,
+    ),
+    buttonPositionPlaylist: await buttonPosition(
+      ButtonPositionContext.Playlist,
+    ),
+    buttonPositionEndscreenModern: await buttonPosition(
+      ButtonPositionContext.EndscreenModern,
+    ),
+    buttonPositionSidebar: await buttonPosition(
+      ButtonPositionContext.Sidebar,
+    ),
+    buttonPositionNotification: await buttonPosition(
+      ButtonPositionContext.Notification,
+    ),
+    buttonPositionEndscreen: await buttonPosition(
+      ButtonPositionContext.Endscreen,
+    ),
     buttonVisibility: await buttonVisibility(),
     loggingEnabled: await loggingEnabled(),
     markNotificationsAsRead: await markNotificationsAsRead(),

--- a/src/components/ButtonPositionSettings.tsx
+++ b/src/components/ButtonPositionSettings.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+
+import { useStorage } from '@plasmohq/storage/hook'
+
+import PositionPicker from '~components/PositionPicker'
+import {
+  ButtonPositionContext,
+  buttonPositionAllowed,
+  buttonPositionDefault,
+} from '~types'
+
+const locations = [
+  {
+    context: ButtonPositionContext.Thumbnail,
+    label: 'Grid videos',
+    description:
+      'Videos shown on the home page, channel pages, and search results.',
+  },
+  {
+    context: ButtonPositionContext.Playlist,
+    label: 'Playlist videos',
+    description: 'Videos shown on a playlist page.',
+  },
+  {
+    context: ButtonPositionContext.EndscreenModern,
+    label: 'Endscreen suggestions',
+    description: 'Suggested videos shown in the grid when a video ends.',
+  },
+  {
+    context: ButtonPositionContext.Sidebar,
+    label: 'Player sidebar',
+    description: 'Suggested videos shown next to the video player.',
+  },
+  {
+    context: ButtonPositionContext.Notification,
+    label: 'Notifications',
+    description: 'Videos shown in the notification drawer.',
+  },
+  {
+    context: ButtonPositionContext.Endscreen,
+    label: 'Old endscreen suggestions',
+    description: 'Suggested videos shown in the older endscreen layout.',
+  },
+]
+
+interface LocationSettingProps {
+  context: string
+  label: string
+  description: string
+}
+
+const LocationSetting = ({
+  context,
+  label,
+  description,
+}: LocationSettingProps) => {
+  const [position, setPosition, { isLoading }] = useStorage<string>(
+    context,
+    buttonPositionDefault[context],
+  )
+
+  return (
+    <div className="setting">
+      <h3 className="title">{label}</h3>
+
+      {isLoading ? (
+        <div className="position-picker" />
+      ) : (
+        <PositionPicker
+          value={position}
+          allowed={buttonPositionAllowed[context]}
+          onChange={setPosition}
+        />
+      )}
+
+      <p className="instruction spacing">{description}</p>
+    </div>
+  )
+}
+
+const ButtonPositionSettings = () => {
+  return (
+    <div className="content">
+      <h2 className="title">Button position</h2>
+
+      <p className="instruction">
+        A page reload is required for these settings to take effect.
+      </p>
+
+      {locations.map(({ context, label, description }) => (
+        <LocationSetting
+          key={context}
+          context={context}
+          label={label}
+          description={description}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default ButtonPositionSettings

--- a/src/components/ButtonPositionSettings.tsx
+++ b/src/components/ButtonPositionSettings.tsx
@@ -83,10 +83,6 @@ const ButtonPositionSettings = () => {
     <div className="content">
       <h2 className="title">Button position</h2>
 
-      <p className="instruction">
-        A page reload is required for these settings to take effect.
-      </p>
-
       {locations.map(({ context, label, description }) => (
         <LocationSetting
           key={context}

--- a/src/components/ExtensionHeader.tsx
+++ b/src/components/ExtensionHeader.tsx
@@ -6,11 +6,22 @@ import '~css/shared.css'
 interface Props {
   title: string
   subtitle?: string
+  onBack?: () => void
 }
 
-const ExtensionHeader = ({ title, subtitle }: Props) => {
+const ExtensionHeader = ({ title, subtitle, onBack }: Props) => {
   return (
     <div className="header">
+      {onBack && (
+        <button
+          type="button"
+          className="back-arrow"
+          aria-label="Back"
+          onClick={onBack}>
+          ←
+        </button>
+      )}
+
       <img className="logo" src={logo} alt="logo" />
 
       <h1 className="title">{title}</h1>

--- a/src/components/PositionPicker.tsx
+++ b/src/components/PositionPicker.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { ButtonPosition } from '~types'
+
+interface Props {
+  value: string
+  allowed: string[]
+  onChange: (value: string) => void
+}
+
+const cornerStyle: Record<string, React.CSSProperties> = {
+  [ButtonPosition.TopLeft]: { top: 4, left: 4 },
+  [ButtonPosition.TopRight]: { top: 4, right: 4 },
+  [ButtonPosition.BottomLeft]: { bottom: 4, left: 4 },
+  [ButtonPosition.BottomRight]: { bottom: 4, right: 4 },
+}
+
+const PositionPicker = ({ value, allowed, onChange }: Props) => {
+  return (
+    <div className="position-picker">
+      {allowed.map((position) => (
+        <button
+          key={position}
+          type="button"
+          aria-label={position}
+          aria-pressed={value === position}
+          className={
+            value === position
+              ? 'position-picker-dot active'
+              : 'position-picker-dot'
+          }
+          style={cornerStyle[position]}
+          onClick={() => onChange(position)}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default PositionPicker

--- a/src/contents/button.styles.ts
+++ b/src/contents/button.styles.ts
@@ -62,8 +62,39 @@ export const buttonStyles = `
 
 .watch-later-btn.in-endscreen-suggested {
     left: 5px;
+    right: unset;
+}
+
+.watch-later-btn.in-endscreen-suggested.top-left,
+.watch-later-btn.in-endscreen-suggested.top-right {
+    top: 4px;
+    bottom: unset;
+}
+
+.watch-later-btn.in-endscreen-suggested.bottom-left,
+.watch-later-btn.in-endscreen-suggested.bottom-right {
+    top: unset;
+    bottom: 4px;
+}
+
+.watch-later-btn.in-mod-endscreen-suggested.top-right {
+    left: unset;
+    top: 4px;
+    right: 5px;
+    bottom: unset;
+}
+
+.watch-later-btn.in-mod-endscreen-suggested.bottom-left {
+    left: 5px;
     top: unset;
     right: unset;
+    bottom: 4px;
+}
+
+.watch-later-btn.in-mod-endscreen-suggested.bottom-right {
+    left: unset;
+    top: unset;
+    right: 5px;
     bottom: 4px;
 }
 
@@ -87,7 +118,8 @@ export const buttonStyles = `
 .watch-later-btn.dark.in-thumbnail,
 .watch-later-btn.dark.in-playlist,
 .watch-later-btn.dark.in-endscreen-suggested,
-.watch-later-btn.dark.in-mod-endscreen-suggested {
+.watch-later-btn.dark.in-mod-endscreen-suggested,
+.watch-later-btn.dark.in-player-suggested {
     background-color: #282828;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
@@ -100,6 +132,7 @@ export const buttonStyles = `
 .watch-later-btn.light.in-playlist,
 .watch-later-btn.light.in-endscreen-suggested,
 .watch-later-btn.light.in-mod-endscreen-suggested,
+.watch-later-btn.light.in-player-suggested,
 .watch-later-btn.light.on-video-detail {
     background-color: rgba(0,0,0,0.05);
 }
@@ -115,16 +148,36 @@ export const buttonStyles = `
 
 .watch-later-btn.in-notification {
     left: unset;
-    top: unset;
     right: 10px;
+}
+
+.watch-later-btn.in-notification.top-left,
+.watch-later-btn.in-notification.top-right {
+    top: 8px;
+    bottom: unset;
+}
+
+.watch-later-btn.in-notification.bottom-left,
+.watch-later-btn.in-notification.bottom-right {
+    top: unset;
     bottom: 8px;
 }
 
 .watch-later-btn.in-player-suggested {
-    left: unset;
+    left: 5px;
+    right: unset;
+}
+
+.watch-later-btn.in-player-suggested.top-left,
+.watch-later-btn.in-player-suggested.top-right {
+    top: 4px;
+    bottom: unset;
+}
+
+.watch-later-btn.in-player-suggested.bottom-left,
+.watch-later-btn.in-player-suggested.bottom-right {
     top: unset;
-    right: -10px;
-    bottom: 8px;
+    bottom: 4px;
 }
 
 .watch-later-btn.on-video-detail {

--- a/src/contents/button.styles.ts
+++ b/src/contents/button.styles.ts
@@ -8,6 +8,11 @@ export const buttonStyles = `
     position: unset !important;
 }
 
+ytd-thumbnail:has(> #plasmo-shadow-container),
+yt-thumbnail-view-model:has(> #plasmo-shadow-container) {
+    position: relative;
+}
+
 #plasmo-shadow-container:has(.watch-later-btn.in-notification.spaced) {
     margin-top: 60px;
 }

--- a/src/contents/button.styles.ts
+++ b/src/contents/button.styles.ts
@@ -44,6 +44,22 @@ export const buttonStyles = `
     bottom: unset;
 }
 
+.watch-later-btn.in-thumbnail.bottom-left,
+.watch-later-btn.in-playlist.bottom-left {
+    left: 5px;
+    top: unset;
+    right: unset;
+    bottom: 4px;
+}
+
+.watch-later-btn.in-thumbnail.bottom-right,
+.watch-later-btn.in-playlist.bottom-right {
+    left: unset;
+    top: unset;
+    right: 5px;
+    bottom: 4px;
+}
+
 .watch-later-btn.in-endscreen-suggested {
     left: 5px;
     top: unset;

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -30,7 +30,12 @@ import {
 import useVideoPreviewListener from '~hooks/useVideoPreviewListener'
 import type { ButtonConfig, YTData } from '~interfaces'
 import { useWatchLaterStore } from '~store'
-import { ButtonOpacity, ButtonPosition, ButtonVisibility } from '~types'
+import {
+  ButtonOpacity,
+  ButtonPosition,
+  ButtonPositionContext,
+  ButtonVisibility,
+} from '~types'
 
 import { buttonStyles } from './button.styles'
 
@@ -285,7 +290,22 @@ const WatchLaterButton = ({ anchor }) => {
 
   const fetchButtonConfig = async () => {
     const opacity = await buttonOpacity()
-    const position = await buttonPosition()
+
+    let positionContext: string | null = null
+    if (isInPlaylist) positionContext = ButtonPositionContext.Playlist
+    else if (isInModernEndscreenSuggested)
+      positionContext = ButtonPositionContext.EndscreenModern
+    else if (isInEndscreenSuggested)
+      positionContext = ButtonPositionContext.Endscreen
+    else if (isInPlayerSuggested)
+      positionContext = ButtonPositionContext.Sidebar
+    else if (isInNotification)
+      positionContext = ButtonPositionContext.Notification
+    else if (isInThumbnail) positionContext = ButtonPositionContext.Thumbnail
+
+    const position = positionContext
+      ? await buttonPosition(positionContext)
+      : null
     const visibility = await buttonVisibility()
 
     setButtonConfig({

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -21,14 +21,9 @@ import {
   elementIsOnVideoDetailPage,
   elementNeedsButton,
 } from '~helpers/matching'
-import {
-  buttonOpacity,
-  buttonPosition,
-  buttonVisibility,
-  markNotificationsAsRead,
-} from '~helpers/system'
+import { getSettings, markNotificationsAsRead } from '~helpers/system'
 import useVideoPreviewListener from '~hooks/useVideoPreviewListener'
-import type { ButtonConfig, YTData } from '~interfaces'
+import type { ButtonConfig, Settings, YTData } from '~interfaces'
 import { useWatchLaterStore } from '~store'
 import {
   ButtonOpacity,
@@ -105,6 +100,22 @@ export const mountShadowHost: PlasmoMountShadowHost = ({
   }
 
   mountState.observer.disconnect()
+}
+
+const computeButtonConfig = (
+  settings: Settings,
+  positionContext: string | null,
+  previous: ButtonConfig,
+): ButtonConfig => {
+  const position = positionContext
+    ? (settings[positionContext as keyof Settings] as string)
+    : null
+
+  return {
+    opacity: settings.buttonOpacity || previous.opacity,
+    position: position || previous.position,
+    visibility: settings.buttonVisibility || previous.visibility,
+  }
 }
 
 const startIntervals = () => {
@@ -213,6 +224,17 @@ const WatchLaterButton = ({ anchor }) => {
   const isInPlayerSuggested = elementIsInPlayerSuggested(element)
   const isInPlayerSuggestedMobile = elementIsInMobilePlayerSuggested(element)
 
+  let positionContext: string | null = null
+  if (isInPlaylist) positionContext = ButtonPositionContext.Playlist
+  else if (isInModernEndscreenSuggested)
+    positionContext = ButtonPositionContext.EndscreenModern
+  else if (isInEndscreenSuggested)
+    positionContext = ButtonPositionContext.Endscreen
+  else if (isInPlayerSuggested) positionContext = ButtonPositionContext.Sidebar
+  else if (isInNotification)
+    positionContext = ButtonPositionContext.Notification
+  else if (isInThumbnail) positionContext = ButtonPositionContext.Thumbnail
+
   const buttonClasses = useMemo(() => {
     let classes = ['watch-later-btn']
 
@@ -289,30 +311,17 @@ const WatchLaterButton = ({ anchor }) => {
   ])
 
   const fetchButtonConfig = async () => {
-    const opacity = await buttonOpacity()
+    const settings = await getSettings()
+    setButtonConfig((previous) =>
+      computeButtonConfig(settings, positionContext, previous),
+    )
+  }
 
-    let positionContext: string | null = null
-    if (isInPlaylist) positionContext = ButtonPositionContext.Playlist
-    else if (isInModernEndscreenSuggested)
-      positionContext = ButtonPositionContext.EndscreenModern
-    else if (isInEndscreenSuggested)
-      positionContext = ButtonPositionContext.Endscreen
-    else if (isInPlayerSuggested)
-      positionContext = ButtonPositionContext.Sidebar
-    else if (isInNotification)
-      positionContext = ButtonPositionContext.Notification
-    else if (isInThumbnail) positionContext = ButtonPositionContext.Thumbnail
-
-    const position = positionContext
-      ? await buttonPosition(positionContext)
-      : null
-    const visibility = await buttonVisibility()
-
-    setButtonConfig({
-      opacity: opacity || buttonConfig.opacity,
-      position: position || buttonConfig.position,
-      visibility: visibility || buttonConfig.visibility,
-    })
+  const handleSettingsChanged = (event) => {
+    const settings = event.detail as Settings
+    setButtonConfig((previous) =>
+      computeButtonConfig(settings, positionContext, previous),
+    )
   }
 
   const addVideo = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -502,6 +511,7 @@ const WatchLaterButton = ({ anchor }) => {
 
     setEnabledFromYtData()
     fetchButtonConfig()
+    window.addEventListener('ytwl-settings-changed', handleSettingsChanged)
 
     if (ytData) {
       setHasData(true)
@@ -524,6 +534,10 @@ const WatchLaterButton = ({ anchor }) => {
     window.removeEventListener('ytwl-yt', setYtwlYt)
     window.removeEventListener('ytwl-yt-nav-start', handleNavigateStart)
     window.removeEventListener('ytwl-yt-nav-finish', handleNavigateFinish)
+    window.removeEventListener(
+      'ytwl-settings-changed',
+      handleSettingsChanged,
+    )
   }
 
   useEffect(() => {

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -95,6 +95,15 @@ export const mountShadowHost: PlasmoMountShadowHost = ({
 
   if (elementIsInMobilePlayerSuggested(element)) {
     element.appendChild(shadowHost)
+  } else if (elementIsInThumbnail(element)) {
+    // Mount inside the thumbnail image wrapper (rather than the whole video
+    // card) so absolute positioning is relative to the thumbnail itself, not
+    // the card including the title/channel metadata below it.
+    const thumbnail = element.querySelector(
+      'ytd-thumbnail, yt-thumbnail-view-model',
+    )
+    const mountTarget = thumbnail ?? element
+    mountTarget.insertBefore(shadowHost, mountTarget.firstChild)
   } else {
     element.insertBefore(shadowHost, element.firstChild)
   }

--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -212,6 +212,7 @@ const WatchLaterButton = ({ anchor }) => {
     position: ButtonPosition.TopLeft,
     visibility: ButtonVisibility.Always,
   })
+  const [configLoaded, setConfigLoaded] = useState<boolean>(false)
   const [isHovered, setIsHovered] = useState(false)
 
   const isInThumbnail = elementIsInThumbnail(element)
@@ -295,6 +296,7 @@ const WatchLaterButton = ({ anchor }) => {
   }, [status, ytData?.clientTheme, buttonConfig])
 
   const shouldShow = useMemo(() => {
+    if (!configLoaded) return false
     if (status === 0) return false
     if (isOnVideoDetail) return true // Always show on video detail page
     if (buttonConfig.visibility === ButtonVisibility.Always) return true
@@ -302,6 +304,7 @@ const WatchLaterButton = ({ anchor }) => {
     if (videoPreviewIsHovered && latestElementRef === element) return true
     return false
   }, [
+    configLoaded,
     status,
     buttonConfig,
     isHovered,
@@ -315,6 +318,7 @@ const WatchLaterButton = ({ anchor }) => {
     setButtonConfig((previous) =>
       computeButtonConfig(settings, positionContext, previous),
     )
+    setConfigLoaded(true)
   }
 
   const handleSettingsChanged = (event) => {

--- a/src/contents/main.ts
+++ b/src/contents/main.ts
@@ -2,6 +2,10 @@ import type { PlasmoCSConfig } from 'plasmo'
 
 import { sendToBackground } from '@plasmohq/messaging'
 import { relay } from '@plasmohq/messaging/relay'
+import { Storage } from '@plasmohq/storage'
+
+import type { Settings } from '~interfaces'
+import { ButtonPositionContext } from '~types'
 
 export const config: PlasmoCSConfig = {
   matches: ['*://*.youtube.com/*'],
@@ -25,4 +29,30 @@ relay(
     const result = await sendToBackground(req)
     return result
   },
+)
+
+const watchedButtonSettingsKeys = [
+  'buttonOpacity',
+  'buttonVisibility',
+  ButtonPositionContext.Thumbnail,
+  ButtonPositionContext.Playlist,
+  ButtonPositionContext.EndscreenModern,
+  ButtonPositionContext.Sidebar,
+  ButtonPositionContext.Notification,
+  ButtonPositionContext.Endscreen,
+]
+
+const storage = new Storage()
+
+const onButtonSettingsChanged = async () => {
+  const settings: Settings = await sendToBackground({ name: 'settings' })
+  window.dispatchEvent(
+    new CustomEvent('ytwl-settings-changed', { detail: settings }),
+  )
+}
+
+storage.watch(
+  Object.fromEntries(
+    watchedButtonSettingsKeys.map((key) => [key, onButtonSettingsChanged]),
+  ),
 )

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,5 +1,8 @@
+html,
 body {
   width: 300px;
+  height: 600px;
+  overflow-y: auto;
 }
 
 .button.small {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -65,3 +65,33 @@ body {
 .content .setting .hover {
   display: none;
 }
+
+.position-picker {
+  position: relative;
+  width: 60px;
+  height: 40px;
+  margin: 6px 0;
+  background-color: #3d3d3d;
+  border: 1px solid #4d4d4d;
+  border-radius: 4px;
+}
+
+.position-picker-dot {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  padding: 0;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  background-color: transparent;
+  cursor: pointer;
+  transition: all var(--animation-speed);
+}
+
+.position-picker-dot:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.position-picker-dot.active {
+  background-color: #fff;
+}

--- a/src/css/shared.css
+++ b/src/css/shared.css
@@ -15,11 +15,15 @@ body {
 }
 
 h1 {
-  font-size: 24px;
+  font-size: 18px;
 }
 
 h2 {
-  font-size: 18px;
+  font-size: 14px;
+}
+
+h3 {
+  font-size: 12px;
 }
 
 a {
@@ -32,7 +36,7 @@ a {
   text-decoration: none;
   cursor: pointer;
   background-color: #3d3d3d;
-  padding: 10px;
+  padding: 8px;
   border: 1px solid #3d3d3d;
   text-align: center;
   display: inline-block;

--- a/src/css/shared.css
+++ b/src/css/shared.css
@@ -62,9 +62,27 @@ a {
 }
 
 .header {
+  position: relative;
   text-align: center;
   background-color: #3d3d3d;
   padding: 10px;
+}
+
+.header .back-arrow {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.header .back-arrow:hover {
+  opacity: 0.75;
 }
 
 .header .logo {

--- a/src/css/whats-new.css
+++ b/src/css/whats-new.css
@@ -1,4 +1,5 @@
-* {
+.whats-new-root,
+.whats-new-root * {
   font-size: 14px;
   box-sizing: border-box;
 }

--- a/src/helpers/system.ts
+++ b/src/helpers/system.ts
@@ -10,12 +10,12 @@ export const buttonOpacity = async (): Promise<string> => {
   return settings.buttonOpacity
 }
 
-export const buttonPosition = async (): Promise<string> => {
+export const buttonPosition = async (context: string): Promise<string> => {
   const settings: Settings = await sendToBackgroundViaRelay<Settings>({
     name: 'settings',
   })
 
-  return settings.buttonPosition
+  return settings[context as keyof Settings] as string
 }
 
 export const buttonVisibility = async (): Promise<string> => {

--- a/src/helpers/system.ts
+++ b/src/helpers/system.ts
@@ -2,28 +2,10 @@ import { sendToBackgroundViaRelay } from '@plasmohq/messaging'
 
 import type { Settings } from '~interfaces'
 
-export const buttonOpacity = async (): Promise<string> => {
-  const settings: Settings = await sendToBackgroundViaRelay<Settings>({
+export const getSettings = async (): Promise<Settings> => {
+  return sendToBackgroundViaRelay<Settings>({
     name: 'settings',
   })
-
-  return settings.buttonOpacity
-}
-
-export const buttonPosition = async (context: string): Promise<string> => {
-  const settings: Settings = await sendToBackgroundViaRelay<Settings>({
-    name: 'settings',
-  })
-
-  return settings[context as keyof Settings] as string
-}
-
-export const buttonVisibility = async (): Promise<string> => {
-  const settings: Settings = await sendToBackgroundViaRelay<Settings>({
-    name: 'settings',
-  })
-
-  return settings.buttonVisibility
 }
 
 export const loggingEnabled = async (): Promise<boolean> => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,12 @@ export interface YTData {
 
 export interface Settings {
   buttonOpacity: string
-  buttonPosition: string
+  buttonPositionThumbnail: string
+  buttonPositionPlaylist: string
+  buttonPositionEndscreenModern: string
+  buttonPositionSidebar: string
+  buttonPositionNotification: string
+  buttonPositionEndscreen: string
   buttonVisibility: string
   loggingEnabled: boolean
   markNotificationsAsRead: boolean

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -177,6 +177,30 @@ const Popup = () => {
               <span className="status">Move to top right</span>
             </div>
           </button>
+
+          <button
+            className="button w-half"
+            disabled={buttonPosition === ButtonPosition.BottomLeft}
+            onClick={() => setButtonPosition(ButtonPosition.BottomLeft)}>
+            <div className="default">
+              <span className="status">Bottom left</span>
+            </div>
+            <div className="hover">
+              <span className="status">Move to bottom left</span>
+            </div>
+          </button>
+
+          <button
+            className="button w-half"
+            disabled={buttonPosition === ButtonPosition.BottomRight}
+            onClick={() => setButtonPosition(ButtonPosition.BottomRight)}>
+            <div className="default">
+              <span className="status">Bottom right</span>
+            </div>
+            <div className="hover">
+              <span className="status">Move to bottom right</span>
+            </div>
+          </button>
         </div>
       </div>
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,15 +1,23 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { useStorage } from '@plasmohq/storage/hook'
 
+import ButtonPositionSettings from '~components/ButtonPositionSettings'
 import ExtensionFooter from '~components/ExtensionFooter'
 import ExtensionHeader from '~components/ExtensionHeader'
 import { openTab } from '~helpers/browser'
-import { ButtonOpacity, ButtonPosition, ButtonVisibility } from '~types'
+import { ButtonOpacity, ButtonVisibility } from '~types'
 
 import '~css/popup.css'
 
 const Popup = () => {
+  const [view, setView] = useState<'main' | 'positions'>('main')
+
+  useEffect(() => {
+    document.body.scrollTop = 0
+    document.documentElement.scrollTop = 0
+  }, [view])
+
   const [isLogging, setIsLogging] = useStorage<boolean>('isLogging', false)
   const [markNotificationsAsRead, setMarkNotificationsAsRead] =
     useStorage<boolean>('markNotificationsAsRead', false)
@@ -21,10 +29,21 @@ const Popup = () => {
     'buttonOpacity',
     ButtonOpacity.Full,
   )
-  const [buttonPosition, setButtonPosition] = useStorage<string>(
-    'buttonPosition',
-    ButtonPosition.TopLeft,
-  )
+
+  if (view === 'positions') {
+    return (
+      <div className="popup-root">
+        <ExtensionHeader
+          title="Button position"
+          onBack={() => setView('main')}
+        />
+
+        <ButtonPositionSettings />
+
+        <ExtensionFooter />
+      </div>
+    )
+  }
 
   return (
     <div className="popup-root">
@@ -92,7 +111,7 @@ const Popup = () => {
 
         <p className="instruction spacing">
           These settings do not affect the button inside the video player
-          controls and in the suggested videos next to/below the player.
+          controls or in suggested videos on mobile.
         </p>
 
         <div className="setting">
@@ -154,52 +173,8 @@ const Popup = () => {
         <div className="setting">
           <h3 className="title">Button position</h3>
 
-          <button
-            className="button w-half"
-            disabled={buttonPosition === ButtonPosition.TopLeft}
-            onClick={() => setButtonPosition(ButtonPosition.TopLeft)}>
-            <div className="default">
-              <span className="status">Top left</span>
-            </div>
-            <div className="hover">
-              <span className="status">Move to top left</span>
-            </div>
-          </button>
-
-          <button
-            className="button w-half"
-            disabled={buttonPosition === ButtonPosition.TopRight}
-            onClick={() => setButtonPosition(ButtonPosition.TopRight)}>
-            <div className="default">
-              <span className="status">Top right</span>
-            </div>
-            <div className="hover">
-              <span className="status">Move to top right</span>
-            </div>
-          </button>
-
-          <button
-            className="button w-half"
-            disabled={buttonPosition === ButtonPosition.BottomLeft}
-            onClick={() => setButtonPosition(ButtonPosition.BottomLeft)}>
-            <div className="default">
-              <span className="status">Bottom left</span>
-            </div>
-            <div className="hover">
-              <span className="status">Move to bottom left</span>
-            </div>
-          </button>
-
-          <button
-            className="button w-half"
-            disabled={buttonPosition === ButtonPosition.BottomRight}
-            onClick={() => setButtonPosition(ButtonPosition.BottomRight)}>
-            <div className="default">
-              <span className="status">Bottom right</span>
-            </div>
-            <div className="hover">
-              <span className="status">Move to bottom right</span>
-            </div>
+          <button className="button" onClick={() => setView('positions')}>
+            <span className="status">Button position settings →</span>
           </button>
         </div>
       </div>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -106,10 +106,6 @@ const Popup = () => {
         <h2 className="title">Button settings</h2>
 
         <p className="instruction">
-          A page reload is required for these settings to take effect.
-        </p>
-
-        <p className="instruction spacing">
           These settings do not affect the button inside the video player
           controls or in suggested videos on mobile.
         </p>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -27,7 +27,7 @@ const Popup = () => {
   )
 
   return (
-    <div className="root">
+    <div className="popup-root">
       <ExtensionHeader title="YouTube Watch Later" />
 
       <div className="content">

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export class ButtonOpacity {
 export class ButtonPosition {
   static TopLeft = 'top-left'
   static TopRight = 'top-right'
+  static BottomLeft = 'bottom-left'
+  static BottomRight = 'bottom-right'
 }
 
 export class ButtonVisibility {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,54 @@ export class ButtonVisibility {
   static Always = 'visibility-always'
   static Hover = 'visibility-hover'
 }
+
+export class ButtonPositionContext {
+  static Thumbnail = 'buttonPositionThumbnail'
+  static Playlist = 'buttonPositionPlaylist'
+  static EndscreenModern = 'buttonPositionEndscreenModern'
+  static Sidebar = 'buttonPositionSidebar'
+  static Notification = 'buttonPositionNotification'
+  static Endscreen = 'buttonPositionEndscreen'
+}
+
+export const buttonPositionAllowed: Record<string, string[]> = {
+  [ButtonPositionContext.Thumbnail]: [
+    ButtonPosition.TopLeft,
+    ButtonPosition.TopRight,
+    ButtonPosition.BottomLeft,
+    ButtonPosition.BottomRight,
+  ],
+  [ButtonPositionContext.Playlist]: [
+    ButtonPosition.TopLeft,
+    ButtonPosition.TopRight,
+    ButtonPosition.BottomLeft,
+    ButtonPosition.BottomRight,
+  ],
+  [ButtonPositionContext.EndscreenModern]: [
+    ButtonPosition.TopLeft,
+    ButtonPosition.TopRight,
+    ButtonPosition.BottomLeft,
+    ButtonPosition.BottomRight,
+  ],
+  [ButtonPositionContext.Sidebar]: [
+    ButtonPosition.TopLeft,
+    ButtonPosition.BottomLeft,
+  ],
+  [ButtonPositionContext.Notification]: [
+    ButtonPosition.TopRight,
+    ButtonPosition.BottomRight,
+  ],
+  [ButtonPositionContext.Endscreen]: [
+    ButtonPosition.TopLeft,
+    ButtonPosition.BottomLeft,
+  ],
+}
+
+export const buttonPositionDefault: Record<string, string> = {
+  [ButtonPositionContext.Thumbnail]: ButtonPosition.TopLeft,
+  [ButtonPositionContext.Playlist]: ButtonPosition.TopLeft,
+  [ButtonPositionContext.EndscreenModern]: ButtonPosition.TopLeft,
+  [ButtonPositionContext.Sidebar]: ButtonPosition.TopLeft,
+  [ButtonPositionContext.Notification]: ButtonPosition.TopRight,
+  [ButtonPositionContext.Endscreen]: ButtonPosition.TopLeft,
+}


### PR DESCRIPTION
## Features

- Reworked positioning settings to allow setting a position per button location
- Added functionality to directly apply settings, without needing to reload

## Changes

- Decreased popup font size
- Lowered popup max height
- Delay initial button showing until settings are loaded
- In case of thumbnail, mount to the thumbnail container for better positioning

## Screenshots

Example of the new popup style:

<img width="602" height="1194" alt="42205" src="https://github.com/user-attachments/assets/00c5ac40-6f85-4dda-8ea1-afbd6b0c3e86" />

Example of the new button positioning settings:

<img width="592" height="1194" alt="71456" src="https://github.com/user-attachments/assets/7e197992-cb51-4a0c-ada0-6aa174f1cd67" />
