### PR TITLE
Feat: Add a setting for auto-open ‘whats new’ tab on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ The button is available in the following locations:
 
 The following general settings can be configured:
 
-| Setting                    | Description                                                                                      | Default  | Notes                                                   |
-|----------------------------|--------------------------------------------------------------------------------------------------|----------|---------------------------------------------------------|
-| Mark notifications as read | Allow notifications to be marked as read when you add those videos to your Watch Later playlist. | disabled | Only affects the button inside the notification drawer. |
-| Logging                    | Allow the extension to send logs to your console. Could be useful for debugging purposes.        | disabled |                                                         |
+| Setting                    | Description                                                                                      | Default  | Notes                                                   | Since  |
+|----------------------------|--------------------------------------------------------------------------------------------------|----------|---------------------------------------------------------|--------|
+| Mark notifications as read | Allow notifications to be marked as read when you add those videos to your Watch Later playlist. | disabled | Only affects the button inside the notification drawer. |        |
+| Logging                    | Allow the extension to send logs to your console. Could be useful for debugging purposes.        | disabled |                                                         |        |
+| Open What's New on update  | Automatically open a new tab with the latest changes after an update.                            | disabled |                                                         | v0.6.1 |
 
 ### Button
 

--- a/docs/store-listing.md
+++ b/docs/store-listing.md
@@ -18,6 +18,7 @@ The following general settings can be configured:
 
 - 'Mark notifications as read' allows for notifications to be marked as read when you add those videos to your Watch Later playlist.
 - 'Logging' allows the plugin to send logs to your console. Could be useful for debugging purposes.
+- (v0.6.1+) 'Open What's New on update' automatically opens a new tab with the latest changes after an update.
 
 The following button settings can be configured:
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -48,6 +48,13 @@ chrome.runtime.onInstalled.addListener(async ({ reason }) => {
     reason === 'update' &&
     changelog.some((c: ChangelogVersion) => c.version === packageJson.version)
   ) {
-    chrome.tabs.create({ url: chrome.runtime.getURL('tabs/whats-new.html') })
+    const storage = new Storage()
+    const openWhatsNewOnUpdate = await storage.get<boolean>(
+      'openWhatsNewOnUpdate',
+    )
+
+    if (openWhatsNewOnUpdate) {
+      chrome.tabs.create({ url: chrome.runtime.getURL('tabs/whats-new.html') })
+    }
   }
 })

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -29,6 +29,10 @@ const Popup = () => {
     'buttonOpacity',
     ButtonOpacity.Full,
   )
+  const [openWhatsNewOnUpdate, setOpenWhatsNewOnUpdate] = useStorage<boolean>(
+    'openWhatsNewOnUpdate',
+    false,
+  )
 
   if (view === 'positions') {
     return (
@@ -98,6 +102,30 @@ const Popup = () => {
 
           <p className="instruction spacing">
             When enabled, logs will be shown in the console.
+          </p>
+        </div>
+
+        <div className="setting">
+          <h3 className="title">Open What's New on update</h3>
+
+          <button
+            className="button"
+            onClick={() => setOpenWhatsNewOnUpdate(!openWhatsNewOnUpdate)}>
+            <div className="default">
+              <span className="status">
+                {openWhatsNewOnUpdate ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+            <div className="hover">
+              <span className="status">
+                {openWhatsNewOnUpdate ? 'Disable' : 'Enable'}
+              </span>
+            </div>
+          </button>
+
+          <p className="instruction spacing">
+            When enabled, a new tab with the latest changes opens automatically
+            after an update.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Features

- Added a setting to toggle showing the "What's New" tab after an update (not [everyone](https://chromewebstore.google.com/reviews/c431b6b5-29f2-49fd-8ea8-7a9c9dc633c4) was liking this apparently). This setting defaults to `true` and can be toggled inside the popup.

## Screenshots

<img width="560" height="202" alt="27500" src="https://github.com/user-attachments/assets/b3b68c2a-237e-4216-85f3-9782b169adee" />
