### PR TITLE
Chore: Repo improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a reproducible bug.
+labels: ["bug"]
 body:
   - type: textarea
     attributes:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,3 +28,9 @@ template: |
   # What's changed
 
   $CHANGES
+
+  ## 📦 Installation
+
+  Install from the official stores: [Chrome Web Store](https://chromewebstore.google.com/detail/youtube-watch-later/nmpfhocciajonacicdelpbhipglapgaa) · [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/youtube-watch-later/hbceknmmffnemncljbkccfgcgnccbale) · [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/youtube-watch-later/)
+  
+  The attached zips are unsigned builds. Stable Firefox only accepts the signed version from Firefox Add-ons; browsers that allow unsigned extensions (Zen, Firefox Developer Edition/Nightly with `xpinstall.signatures.required=false`) can install the Firefox zip by renaming it to `.xpi`.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -29,7 +29,7 @@ template: |
 
   $CHANGES
 
-  ## 📦 Installation
+  # Installation
 
   Install from the official stores: [Chrome Web Store](https://chromewebstore.google.com/detail/youtube-watch-later/nmpfhocciajonacicdelpbhipglapgaa) · [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/youtube-watch-later/hbceknmmffnemncljbkccfgcgnccbale) · [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/youtube-watch-later/)
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - '**/*.ts'
       - '**/*.tsx'
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,25 @@
+name: Lock Threads
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Lock inactive closed issues and PRs
+        uses: dessant/lock-threads@v6
+        with:
+          process-only: 'issues, prs'
+          issue-inactive-days: 90
+          pr-inactive-days: 90

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,39 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark and close stale issues and PRs
+        uses: actions/stale@v11
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: 'pinned,security,good first issue,help wanted'
+          exempt-pr-labels: 'pinned,security,dependencies'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            Leave a comment if this is still relevant.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            recent activity. It will be closed in 14 days if no further activity occurs.
+            Leave a comment if this is still relevant.
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. Feel free to
+            reopen it or open a new issue if it is still relevant.
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity. Feel free
+            to reopen it if it is still relevant.

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,24 @@
+name: Triage
+
+on:
+  issues:
+    types: [ opened ]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add triage label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs triage']
+            })

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
     "vitest": "^4.1.10"
   },
   "manifest": {
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "{767563c0-f773-41a2-afa9-e36cc0d49c31}"
+      }
+    },
     "host_permissions": [
       "https://www.youtube.com/*",
       "https://m.youtube.com/*",


### PR DESCRIPTION
## Changes

- Added a gecko ID to the manifest override
- Added manual installation instructions to the release drafter template
- Added a triage workflow that labels new issues with `needs triage`
- Added a stale workflow that marks issues/PRs as stale after 60 days of inactivity and closes them 14 days later
- Added a lock workflow that locks closed issues/PRs after 90 days of inactivity
- Added the `bug` label to the bug report issue template
- Added concurrency limits to the CI workflow so outdated runs are cancelled

---

Relates to #229.