### PR TITLE
Fix: Ignore transient empty anchor list during hover preview

### DIFF
--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -104,7 +104,19 @@ export const getInlineAnchorList: PlasmoGetInlineAnchorList = async () => {
 }
 
 export const getOverlayAnchorList: PlasmoGetOverlayAnchorList = async () => {
-  return getOverlayAnchorElements() as unknown as NodeList
+  let elements = getOverlayAnchorElements()
+
+  // YouTube's own hover-preview player briefly detaches/reattaches the feed
+  // during layout, which can make every anchor selector miss for a single
+  // poll tick even though nothing actually changed. Treating that as "no
+  // anchors" tears down and rebuilds every mounted button (visible as
+  // flicker), so re-check after a frame before trusting an empty result.
+  if (elements.length === 0) {
+    await new Promise((resolve) => requestAnimationFrame(resolve))
+    elements = getOverlayAnchorElements()
+  }
+
+  return elements as unknown as NodeList
 }
 
 export const watch: PlasmoCSUIWatch = ({ observer }) =>


### PR DESCRIPTION
## Changes

- Treat a single empty overlay-anchor poll as transient instead of authoritative when it follows a non-empty result, by re-checking after one animation frame

## Detailed findings about the flicker/click failure

Fixes #247 and an email report.

YouTube's own hover-preview player briefly detaches and reattaches the video feed during layout when hovering a thumbnail. That detach can land exactly on one of Plasmo's anchor-list poll ticks, so `getOverlayAnchorList` sees zero matching anchors for that tick even though nothing actually changed on the page.

Plasmo treats an empty anchor list as "these overlays no longer apply" and tears down every mounted button for that anchor, then remounts them once the feed reattaches. That teardown/remount cycle on every hover is what showed up as the button flickering, and — because the button element itself gets destroyed and recreated mid-hover — a click landing during that window has nothing mounted to handle it, which is why clicks were being dropped.

The fix re-queries the anchor elements after a `requestAnimationFrame` before accepting an empty result, so a real single-frame layout blip resolves itself instead of triggering a full unmount/remount.