### PR TITLE
Fix: Fall back to __Secure-3PAPISID for SAPISIDHASH when SAPISID is missing

### DIFF
--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -38,8 +38,13 @@ export const getAuthorizationHeader = async () => {
 
   const parts: string[] = []
 
-  if (cookies.sapisid) {
-    parts.push(`SAPISIDHASH ${await computeHash(cookies.sapisid)}`)
+  // Some browsers/accounts no longer set the plain SAPISID cookie. YouTube
+  // accepts __Secure-3PAPISID's value as a SAPISIDHASH fallback in that case
+  // (a SAPISID3PHASH alone is not enough to authorize mutating requests).
+  const primarySapisid = cookies.sapisid ?? cookies.sapisid3p
+
+  if (primarySapisid) {
+    parts.push(`SAPISIDHASH ${await computeHash(primarySapisid)}`)
   }
   if (cookies.sapisid1p) {
     parts.push(`SAPISID1PHASH ${await computeHash(cookies.sapisid1p)}`)


### PR DESCRIPTION
## Changes

- `getAuthorizationHeader` now falls back to the `__Secure-3PAPISID` cookie value for the `SAPISIDHASH` when the plain `sapisid` cookie is absent

## Detailed findings about the Edge "loggedOut" failure

Fixes #236.

@Fred-Vatin's logs showed the request going out with `LOGGED_IN: true` and a valid session, but the cookie header only carried `__Secure-3PAPISID` / `__Secure-3PSID` — no plain `SAPISID`. Some browser/account configurations (this one on Edge) no longer set the legacy plain `SAPISID` cookie at all, only its `__Secure-` prefixed, partitioned variants.

Without `SAPISID`, the extension was only sending `SAPISID1PHASH`/`SAPISID3PHASH`-style headers derived from the other cookies, but never the primary `SAPISIDHASH` YouTube's `edit_playlist` endpoint checks — so the server treated the request as unauthenticated and returned the "Sign in to add this video to a playlist" popup, matching the reported `"loggedOut": true` response.

`__Secure-3PAPISID` carries the same underlying SID value as `SAPISID` when the latter isn't set, so it's now used as a fallback for computing `SAPISIDHASH` specifically (not as a replacement for the existing `SAPISID3PHASH` logic, which stays separate).