### PR TITLE
Fix: Scope Watch Later suppression to actual playlist items

### DIFF
--- a/src/contents/button.tsx
+++ b/src/contents/button.tsx
@@ -494,16 +494,15 @@ const WatchLaterButton = ({ anchor }) => {
   useEffect(() => {
     const isWL = hasSearch(url, 'list', 'WL')
     const isPlaylists = hasPath(url, '/feed/playlists')
+    const isWatchLaterItem =
+      (isOnVideoDetail && isWL) || (isInPlaylist && (isWL || isPlaylists))
 
-    if (
-      !enabled ||
-      (!isInNotification && !isOnVideoDetail && (isWL || isPlaylists))
-    ) {
+    if (!enabled || (!isInNotification && isWatchLaterItem)) {
       setVisible(false)
     } else {
       setVisible(true)
     }
-  }, [enabled, isInNotification, isOnVideoDetail, url])
+  }, [enabled, isInPlaylist, isInNotification, isOnVideoDetail, url])
 
   useEffect(() => {
     if (visible && hasData) {


### PR DESCRIPTION
## Changes

- Button visibility suppression for Watch Later context is now scoped to elements that are actual WL items (the video being played from WL, and items on the WL listing page), instead of every button on the page

## Detailed findings

Fixes #249.

The button was suppressed on any anchor when the page URL had `list=WL` in the query string. That param stays on the URL for the entire watch page while playing a video from Watch Later, not just on the listing page, so the suppression was also hiding buttons on unrelated suggested/recommended videos next to the player - videos that aren't in Watch Later and should still get the button.

It also didn't account for the reverse case: the main button below the actively-playing video should itself be suppressed when that video was opened from the WL queue, since it's already saved there - same as items on the WL listing page.

The fix narrows suppression to `(isOnVideoDetail && isWL) || (isInPlaylist && (isWL || isPlaylists))`, so it only applies to the currently-playing WL video and actual WL listing items, leaving suggested/recommended videos elsewhere on the page unaffected.

Verified live against the built extension (`build/chrome-mv3-prod`) in a real, logged-in YouTube session:
- main button hidden while playing a WL video, shown for the same video played outside WL
- suggested/endscreen videos show their button while playing from WL (the original bug)
- WL listing page items stay hidden