### PR TITLE
fix(overlay): re-render WL buttons on scroll, not just DOM mutation

### DIFF
--- a/src/helpers/overlay.ts
+++ b/src/helpers/overlay.ts
@@ -65,21 +65,24 @@ export const mutationsAffectOverlayAnchors = (mutations: MutationRecord[]) =>
     ),
   )
 
-const OVERLAY_EVICTION_DEBOUNCE_MS = 200
+const OVERLAY_RECHECK_DEBOUNCE_MS = 200
 
 // Plasmo only (re-)renders the overlay host when it doesn't exist yet — once
 // mounted, its own mutation/interval loop keeps recomputing the anchor list
-// but never re-renders it. Evicting the host forces Plasmo's already-running
-// loop to rebuild it with the fresh anchor list on its next pass, instead of
-// leaving buttons stuck on stale (often removed) anchors.
+// (`mountState.overlayTargetList`) but never re-renders it. Evicting the host
+// forces Plasmo's already-running loop to rebuild it with the fresh anchor
+// list on its next pass, instead of leaving buttons stuck on a stale list.
 //
-// This needs to happen both on YouTube navigation and on plain DOM churn
-// (e.g. switching the sidebar between Up next/Related/Chapters swaps its
-// content without a navigation event). The mutation check only ever looks at
-// the nodes a given mutation touched, not the page, so it stays cheap even
-// though it runs on every mutation.
+// "Stale" here isn't just DOM churn (nodes added/removed, e.g. switching the
+// sidebar between Up next/Related/Chapters). On YouTube's virtualized grids
+// (subscriptions feed, home page) scrolling far and back can leave tile
+// nodes in the DOM the whole time — same elements, no mutation at all — with
+// only their on-screen position changing, which is what the anchor list's
+// own visibility filter keys off. So this also has to react to scrolling,
+// not just mutations, or tiles scrolled back into view stay buttonless.
 export const watchOverlayEviction = (observer: CSUIObserver) => {
   let debounceTimeout: ReturnType<typeof setTimeout> | null = null
+  let lastAnchorElements: Element[] = []
 
   const evictOverlayHost = () => {
     const overlayHost = Array.from(observer.mountState.hostSet).find(
@@ -94,17 +97,37 @@ export const watchOverlayEviction = (observer: CSUIObserver) => {
     observer.mountState.hostMap.delete(overlayHost)
   }
 
-  const scheduleEviction = () => {
+  // Only evicts (and pays for rebuilding the overlay host) when the
+  // computed anchor set actually differs from what's currently rendered, so
+  // idle settling after a scroll/mutation is a cheap no-op.
+  const recheckAndEvict = () => {
+    const anchors = getOverlayAnchorElements()
+    const changed =
+      anchors.length !== lastAnchorElements.length ||
+      anchors.some((element) => !lastAnchorElements.includes(element))
+
+    lastAnchorElements = anchors
+    if (changed) evictOverlayHost()
+  }
+
+  const scheduleRecheck = () => {
     if (debounceTimeout) clearTimeout(debounceTimeout)
-    debounceTimeout = setTimeout(evictOverlayHost, OVERLAY_EVICTION_DEBOUNCE_MS)
+    debounceTimeout = setTimeout(recheckAndEvict, OVERLAY_RECHECK_DEBOUNCE_MS)
   }
 
   const mutationObserver = new MutationObserver((mutations) => {
-    if (mutationsAffectOverlayAnchors(mutations)) scheduleEviction()
+    if (mutationsAffectOverlayAnchors(mutations)) scheduleRecheck()
   })
   mutationObserver.observe(document.documentElement, {
     childList: true,
     subtree: true,
+  })
+
+  // Capture phase: YouTube's grids scroll within nested containers, not
+  // necessarily `window`, and `scroll` doesn't bubble.
+  window.addEventListener('scroll', scheduleRecheck, {
+    passive: true,
+    capture: true,
   })
 
   window.addEventListener('ytwl-yt-nav-finish', evictOverlayHost)
@@ -112,6 +135,7 @@ export const watchOverlayEviction = (observer: CSUIObserver) => {
   return () => {
     mutationObserver.disconnect()
     if (debounceTimeout) clearTimeout(debounceTimeout)
+    window.removeEventListener('scroll', scheduleRecheck, true)
     window.removeEventListener('ytwl-yt-nav-finish', evictOverlayHost)
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #245 — the WL overlay button list (subscriptions/home grid) was only ever rebuilt in response to a DOM mutation matching `previewOverlayAnchorSelector`. YouTube's virtualized grid can leave a tile's DOM node completely untouched while the user scrolls it out of and back into view, so a pure scroll with zero mutations never triggered a rebuild — tiles scrolled back into view stayed buttonless.
- `watchOverlayEviction` (`src/helpers/overlay.ts`) now also listens for `scroll` (capture, passive), and on either trigger diffs the freshly-computed anchor set against what's currently rendered, evicting the overlay host (forcing Plasmo to rebuild it) only when the set actually changed.

## Test plan
- [x] `pnpm typecheck` / `eslint` clean
- [x] Built the extension and live-tested in an isolated Chrome profile: reproduced the bug on the unpatched build (scrolled ~530 tiles down then back to top — buttons stayed stuck on the last-evicted set), then confirmed the fix restores buttons correctly aligned to the now-visible top tiles, with no leaked overlay hosts (`plasmo-csui` count stays at 1)
- [x] Measured recheck cost empirically: ~1.5–3ms per scan at 350+ tiles loaded, firing at most once per 200ms debounce after scrolling settles — no per-frame or per-scroll-event cost